### PR TITLE
Auto corrected by following Lint Typescript unicorn/prevent-abbreviations

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,6 +1,6 @@
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
-module.exports = function override(config, env) {
+module.exports = function override(config, environment) {
   config.plugins.push(
     new MonacoWebpackPlugin({
       languages: ["javascript", "ruby"],


### PR DESCRIPTION
Auto corrected by following Lint Typescript unicorn/prevent-abbreviations

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-playground/lint_configs/typescript/139864) to configure it on awesomecode.io